### PR TITLE
Revert "Update postgres Docker tag to v15"

### DIFF
--- a/postgres/bases/kubegres/kustomization.yaml
+++ b/postgres/bases/kubegres/kustomization.yaml
@@ -19,4 +19,4 @@ configurations:
 
 images:
   - name: postgres
-    newTag: "15.4"
+    newTag: "14.9"


### PR DESCRIPTION
Reverts lentzi90/personal-cloud#134

Kubegres cannot handle the major version bump.