### PR TITLE
Nextcloud: use explicit certificate

### DIFF
--- a/nextcloud/overlays/jern.me/certificate.yaml
+++ b/nextcloud/overlays/jern.me/certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: nextcloud-cert
+spec:
+  dnsNames:
+    - nextcloud.jern.me
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: letsencrypt-prod
+  secretName: nextcloud-cert
+  revisionHistoryLimit: 5

--- a/nextcloud/overlays/jern.me/ingress.yaml
+++ b/nextcloud/overlays/jern.me/ingress.yaml
@@ -3,7 +3,6 @@ kind: Ingress
 metadata:
   name: nextcloud
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/proxy-body-size: 500m
 spec:
   ingressClassName: nginx

--- a/nextcloud/overlays/jern.me/kustomization.yaml
+++ b/nextcloud/overlays/jern.me/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 - nextcloud-pv.yaml
 - postgres.yaml
 - scheduled-backup.yaml
+- certificate.yaml
 
 patches:
 - path: deployment.yaml

--- a/nextcloud/overlays/kind/certificate.yaml
+++ b/nextcloud/overlays/kind/certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: nextcloud-cert
+spec:
+  dnsNames:
+    - nextcloud.jern.me
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: selfsigned
+  secretName: nextcloud-cert
+  revisionHistoryLimit: 5

--- a/nextcloud/overlays/kind/ingress.yaml
+++ b/nextcloud/overlays/kind/ingress.yaml
@@ -3,7 +3,6 @@ kind: Ingress
 metadata:
   name: nextcloud
   annotations:
-    cert-manager.io/cluster-issuer: selfsigned
     nginx.ingress.kubernetes.io/proxy-body-size: 500m
 spec:
   ingressClassName: nginx

--- a/nextcloud/overlays/kind/kustomization.yaml
+++ b/nextcloud/overlays/kind/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 - namespace.yaml
 - postgres.yaml
 - scheduled-backup.yaml
+- certificate.yaml
 
 patches:
 - path: deployment.yaml


### PR DESCRIPTION
Instead of Ingress annotation, use an explicit Certificate so we can set revision history limit.