### PR TITLE
Revert "Update dependency prometheus-operator/prometheus-operator to v0.78.0"

### DIFF
--- a/prometheus-operator/base/kustomization.yaml
+++ b/prometheus-operator/base/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/prometheus-operator/prometheus-operator?ref=v0.78.0
+  - https://github.com/prometheus-operator/prometheus-operator?ref=v0.77.2


### PR DESCRIPTION
Reverts lentzi90/personal-cloud#426

Cannot use v0.78.0 until https://github.com/prometheus-operator/prometheus-operator/issues/7061 is fixed.