### PR TITLE
Revert "Update docker.io/jellyfin/jellyfin Docker tag to v10.11.0"

### DIFF
--- a/jellyfin/base/kustomization.yaml
+++ b/jellyfin/base/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 
 images:
 - name: docker.io/jellyfin/jellyfin
-  newTag: 10.11.0
+  newTag: 10.10.7


### PR DESCRIPTION
Reverts lentzi90/personal-cloud#679

Need to change volume mounts as jellyfin now requires 2GB even for config...