### PR TITLE
Add HTTPRoute for longhorn UI

### DIFF
--- a/turing-talos/apps/envoy-gateways/kustomization.yaml
+++ b/turing-talos/apps/envoy-gateways/kustomization.yaml
@@ -9,6 +9,7 @@ labels:
 
 resources:
 - ../../../envoy-gateway/base
+- wildcard-certificate.yaml
 
 patches:
 - path: private-gateway.yaml

--- a/turing-talos/apps/envoy-gateways/private-gateway.yaml
+++ b/turing-talos/apps/envoy-gateways/private-gateway.yaml
@@ -7,3 +7,22 @@ spec:
   addresses:
   - type: IPAddress
     value: 192.168.1.54
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: All
+  - name: https
+    protocol: HTTPS
+    port: 443
+    hostname: "*.jern.fi"
+    allowedRoutes:
+      namespaces:
+        from: All
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        name: wildcard-jern-fi-cert

--- a/turing-talos/apps/envoy-gateways/wildcard-certificate.yaml
+++ b/turing-talos/apps/envoy-gateways/wildcard-certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-jern-fi
+spec:
+  secretName: wildcard-jern-fi-cert
+  dnsNames:
+  - "*.jern.fi"
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: letsencrypt-staging
+  revisionHistoryLimit: 5

--- a/turing-talos/apps/longhorn/httproute.yaml
+++ b/turing-talos/apps/longhorn/httproute.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: longhorn
+spec:
+  parentRefs:
+  - name: envoy-private
+    namespace: envoy-gateway-system
+    sectionName: https
+  hostnames:
+  - longhorn.jern.fi
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: longhorn-frontend
+      port: 80

--- a/turing-talos/apps/longhorn/kustomization.yaml
+++ b/turing-talos/apps/longhorn/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - ../../../longhorn/base
 - certificate.yaml
 - ingress.yaml
+- httproute.yaml
 patches:
 - path: namespace.yaml
 - target:


### PR DESCRIPTION
Try out gateway API with wildcard staging certificate and an HTTPRoute for longhorn UI in the turing-talos environment.