### PR TITLE
Add hetzner-cloud-webhook for cert-manager DNS-01 on Hetzner Cloud

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -10,7 +10,7 @@ jobs:
     uses: ./.github/workflows/kustomize-reusable.yaml
     with:
       paths: >
-        apps/kind argocd/overlays/kind cert-manager/overlays/kind cloudnative-pg/overlays/kind external-secrets/overlays/kind hetzner-acme/overlays/kind keycloak-operator/overlays/kind keycloak/overlays/kind jellyfin/overlays/kind metallb/overlays/kind nginx-ingress/overlays/kind pi-hole/overlays/kind wireguard/overlays/kind opencloud/overlays/kind
+        apps/kind argocd/overlays/kind cert-manager/overlays/kind cloudnative-pg/overlays/kind external-secrets/overlays/kind hetzner-acme/overlays/kind hetzner-cloud-webhook/overlays/kind keycloak-operator/overlays/kind keycloak/overlays/kind jellyfin/overlays/kind metallb/overlays/kind nginx-ingress/overlays/kind pi-hole/overlays/kind wireguard/overlays/kind opencloud/overlays/kind
   kind-deploy:
     needs: kustomize-build
     runs-on: ubuntu-latest

--- a/apps/kind/hetzner-cloud-webhook-app.yaml
+++ b/apps/kind/hetzner-cloud-webhook-app.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hetzner-cloud-webhook
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+spec:
+  destination:
+    namespace: cert-manager
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: hetzner-cloud-webhook/overlays/kind
+    repoURL: https://github.com/lentzi90/personal-cloud.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/apps/kind/kustomization.yaml
+++ b/apps/kind/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - envoy-gateways-app.yaml
 - external-secrets-app.yaml
 - hetzner-acme-app.yaml
+- hetzner-cloud-webhook-app.yaml
 - ingress-nginx-app.yaml
 - jellyfin-app.yaml
 - keycloak-app.yaml

--- a/chainsaw-test.yaml
+++ b/chainsaw-test.yaml
@@ -367,6 +367,38 @@ spec:
     - podLogs:
         name: cert-manager-webhook-hetzner
         namespace: cert-manager
+  # hetzner-cloud-webhook
+  - try:
+    - script:
+        timeout: 10s
+        content: kubectl -n argocd apply -f apps/kind/hetzner-cloud-webhook-app.yaml
+    - assert:
+        timeout: 10m
+        resource:
+          apiVersion: argoproj.io/v1alpha1
+          kind: Application
+          metadata:
+            name: hetzner-cloud-webhook
+            namespace: argocd
+          status:
+            health:
+              status: Healthy
+            sync:
+              status: Synced
+    catch:
+    - describe:
+        apiVersion: argoproj.io/v1alpha1
+        kind: Application
+        name: hetzner-cloud-webhook
+        namespace: argocd
+    - describe:
+        apiVersion: v1
+        kind: Pod
+        name: cert-manager-webhook-hetzner-cloud
+        namespace: cert-manager
+    - podLogs:
+        name: cert-manager-webhook-hetzner-cloud
+        namespace: cert-manager
   # keycloak-operator
   - try:
     - script:

--- a/hetzner-cloud-webhook/base/apiservice.yaml
+++ b/hetzner-cloud-webhook/base/apiservice.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.acme.hetzner.com
+  annotations:
+    cert-manager.io/inject-ca-from: "cert-manager/cert-manager-webhook-hetzner-cloud-webhook-tls"
+spec:
+  group: acme.hetzner.com
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  service:
+    name: cert-manager-webhook-hetzner-cloud
+    namespace: cert-manager
+  version: v1alpha1

--- a/hetzner-cloud-webhook/base/deployment.yaml
+++ b/hetzner-cloud-webhook/base/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cert-manager-webhook-hetzner-cloud
+  namespace: cert-manager
+spec:
+  template:
+    spec:
+      serviceAccountName: cert-manager-webhook-hetzner-cloud
+      containers:
+      - name: cert-manager-webhook-hetzner-cloud
+        image: docker.io/hetzner/cert-manager-webhook-hetzner
+        imagePullPolicy: IfNotPresent
+        args:
+        - --tls-cert-file=/tls/tls.crt
+        - --tls-private-key-file=/tls/tls.key
+        - --secure-port=8443
+        env:
+        - name: GROUP_NAME
+          value: "acme.hetzner.com"
+        ports:
+        - name: https
+          containerPort: 8443
+          protocol: TCP
+        - name: metrics
+          containerPort: 8080
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /healthz
+            port: https
+        readinessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /healthz
+            port: https
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: certs
+          mountPath: /tls
+          readOnly: true
+      volumes:
+      - name: certs
+        secret:
+          secretName: cert-manager-webhook-hetzner-cloud-webhook-tls
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault

--- a/hetzner-cloud-webhook/base/kustomization.yaml
+++ b/hetzner-cloud-webhook/base/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: cert-manager-webhook-hetzner-cloud
+
+images:
+- name: docker.io/hetzner/cert-manager-webhook-hetzner
+  newTag: v0.6.5
+
+resources:
+- apiservice.yaml
+- rbac.yaml
+- deployment.yaml
+- service.yaml
+- webhook-pki.yaml

--- a/hetzner-cloud-webhook/base/rbac.yaml
+++ b/hetzner-cloud-webhook/base/rbac.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-manager-webhook-hetzner-cloud
+  namespace: cert-manager
+---
+# Grant cert-manager permission to validate using our apiserver
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-webhook-hetzner-cloud:domain-solver
+rules:
+- apiGroups:
+  - acme.hetzner.com
+  resources:
+  - '*'
+  verbs:
+  - 'create'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cert-manager-webhook-hetzner-cloud:secret-reader
+  namespace: cert-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  resourceNames:
+  - hetzner-cloud-secret
+  verbs:
+  - "get"
+  - "watch"
+---
+# apiserver gets the auth-delegator role to delegate auth decisions to
+# the core apiserver
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-webhook-hetzner-cloud:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cert-manager-webhook-hetzner-cloud
+  namespace: cert-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-webhook-hetzner-cloud:domain-solver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-webhook-hetzner-cloud:domain-solver
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cert-manager
+  namespace: cert-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cert-manager-webhook-hetzner-cloud:secret-reader
+  namespace: cert-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cert-manager-webhook-hetzner-cloud:secret-reader
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cert-manager-webhook-hetzner-cloud
+  namespace: cert-manager
+---
+# Grant the webhook permission to read the ConfigMap containing the Kubernetes
+# apiserver's requestheader-ca-certificate.
+# This ConfigMap is automatically created by the Kubernetes apiserver.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cert-manager-webhook-hetzner-cloud:webhook-authentication-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cert-manager-webhook-hetzner-cloud
+  namespace: cert-manager

--- a/hetzner-cloud-webhook/base/service.yaml
+++ b/hetzner-cloud-webhook/base/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cert-manager-webhook-hetzner-cloud
+  namespace: cert-manager
+spec:
+  type: ClusterIP
+  ports:
+  - port: 443
+    targetPort: https
+    protocol: TCP
+    name: https
+  - port: 8080
+    targetPort: metrics
+    protocol: TCP
+    name: metrics
+  selector:
+    app.kubernetes.io/name: cert-manager-webhook-hetzner-cloud

--- a/hetzner-cloud-webhook/base/webhook-pki.yaml
+++ b/hetzner-cloud-webhook/base/webhook-pki.yaml
@@ -1,0 +1,39 @@
+# Generate a CA Certificate used to sign certificates for the webhook
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cert-manager-webhook-hetzner-cloud-ca
+  namespace: cert-manager
+spec:
+  secretName: cert-manager-webhook-hetzner-cloud-ca
+  duration: 43800h0m0s # 5y
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer
+  commonName: ca.cert-manager-webhook-hetzner-cloud.cert-manager
+  isCA: true
+---
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: cert-manager-webhook-hetzner-cloud-ca
+  namespace: cert-manager
+spec:
+  ca:
+    secretName: cert-manager-webhook-hetzner-cloud-ca
+---
+# Finally, generate a serving certificate for the webhook to use
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cert-manager-webhook-hetzner-cloud-webhook-tls
+  namespace: cert-manager
+spec:
+  secretName: cert-manager-webhook-hetzner-cloud-webhook-tls
+  issuerRef:
+    name: cert-manager-webhook-hetzner-cloud-ca
+  dnsNames:
+  - cert-manager-webhook-hetzner-cloud
+  - cert-manager-webhook-hetzner-cloud.cert-manager
+  - cert-manager-webhook-hetzner-cloud.cert-manager.svc

--- a/hetzner-cloud-webhook/overlays/kind/kustomization.yaml
+++ b/hetzner-cloud-webhook/overlays/kind/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+secretGenerator:
+- name: hetzner-cloud-secret
+  literals:
+  - token=FAKE

--- a/turing-talos/apps/hetzner-cloud-webhook-app.yaml
+++ b/turing-talos/apps/hetzner-cloud-webhook-app.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hetzner-cloud-webhook
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+spec:
+  destination:
+    namespace: cert-manager
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: turing-talos/apps/hetzner-cloud-webhook
+    repoURL: https://github.com/lentzi90/personal-cloud.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/turing-talos/apps/hetzner-cloud-webhook/externalsecret.yaml
+++ b/turing-talos/apps/hetzner-cloud-webhook/externalsecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hetzner-cloud-secret
+  namespace: cert-manager
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    # This name must match the metadata.name in the `SecretStore`
+    name: bitwarden-personal-cloud
+    kind: ClusterSecretStore
+  data:
+  - secretKey: token
+    remoteRef:
+      # TODO: Replace with the actual Bitwarden item ID for the Hetzner Cloud API token
+      key: c054fbca-6e33-4bb4-a4cd-b3f2009a9271

--- a/turing-talos/apps/hetzner-cloud-webhook/kustomization.yaml
+++ b/turing-talos/apps/hetzner-cloud-webhook/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../hetzner-cloud-webhook/base
+- externalsecret.yaml
+labels:
+- pairs:
+    environment: turing-talos

--- a/turing-talos/apps/kustomization.yaml
+++ b/turing-talos/apps/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 - envoy-gateways-app.yaml
 - external-secrets-app.yaml
 - hetzner-acme-app.yaml
+- hetzner-cloud-webhook-app.yaml
 - ingress-nginx-app.yaml
 - ingress-nginx-external-app.yaml
 - jellyfin-app.yaml


### PR DESCRIPTION
- Introduce hetzner-cloud-webhook manifests and Kustomize overlays
- Register ArgoCD Applications for KinD and turing-talos environments
- Integrate with CI pipeline and Chainsaw integration tests
- Add ExternalSecret for Hetzner Cloud API token in production