### PR TITLE
Add HTTPRoute resources for Gateway API support

### DIFF
--- a/blog/overlays/kind/kustomization.yaml
+++ b/blog/overlays/kind/kustomization.yaml
@@ -9,8 +9,9 @@ labels:
     environment: kind
 
 resources:
-  - ../../base
-  - namespace.yaml
+- ../../base
+- namespace.yaml
+- httproute.yaml
 
 patches:
 - path: ingress.yaml

--- a/jellyfin/overlays/kind/httproute.yaml
+++ b/jellyfin/overlays/kind/httproute.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: jellyfin
+spec:
+  parentRefs:
+  - name: envoy-private
+    namespace: envoy-gateway-system
+    sectionName: https
+  hostnames:
+  - jellyfin.local
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: jellyfin
+      port: 80

--- a/jellyfin/overlays/kind/kustomization.yaml
+++ b/jellyfin/overlays/kind/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
 - namespace.yaml
 - certificate.yaml
 - ingress.yaml
+- httproute.yaml

--- a/opencloud/overlays/kind/httproute.yaml
+++ b/opencloud/overlays/kind/httproute.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: opencloud
+spec:
+  parentRefs:
+  - name: envoy-private
+    namespace: envoy-gateway-system
+    sectionName: https
+  hostnames:
+  - opencloud.local
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: opencloud
+      port: 80

--- a/opencloud/overlays/kind/kustomization.yaml
+++ b/opencloud/overlays/kind/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 - namespace.yaml
 - certificate.yaml
 - ingress.yaml
+- httproute.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/turing-talos/apps/blog/httproute.yaml
+++ b/turing-talos/apps/blog/httproute.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: blog
+spec:
+  parentRefs:
+  - name: envoy-public
+    namespace: envoy-gateway-system
+    sectionName: https-apex
+  hostnames:
+  - jern.fi
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: blog
+      port: 80

--- a/turing-talos/apps/blog/kustomization.yaml
+++ b/turing-talos/apps/blog/kustomization.yaml
@@ -10,6 +10,7 @@ labels:
 resources:
 - ../../../blog/base
 - namespace.yaml
+- httproute.yaml
 
 patches:
 - path: ingress.yaml

--- a/turing-talos/apps/envoy-gateways/apex-certificate.yaml
+++ b/turing-talos/apps/envoy-gateways/apex-certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: apex-jern-fi
+spec:
+  secretName: apex-jern-fi-cert
+  dnsNames:
+  - "jern.fi"
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: letsencrypt-prod
+  revisionHistoryLimit: 5

--- a/turing-talos/apps/envoy-gateways/kustomization.yaml
+++ b/turing-talos/apps/envoy-gateways/kustomization.yaml
@@ -10,6 +10,7 @@ labels:
 resources:
 - ../../../envoy-gateway/base
 - wildcard-certificate.yaml
+- apex-certificate.yaml
 
 patches:
 - path: private-gateway.yaml

--- a/turing-talos/apps/envoy-gateways/private-gateway.yaml
+++ b/turing-talos/apps/envoy-gateways/private-gateway.yaml
@@ -26,3 +26,15 @@ spec:
       certificateRefs:
       - kind: Secret
         name: wildcard-jern-fi-cert
+  - name: https-apex
+    protocol: HTTPS
+    port: 443
+    hostname: jern.fi
+    allowedRoutes:
+      namespaces:
+        from: All
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        name: apex-jern-fi-cert

--- a/turing-talos/apps/envoy-gateways/public-gateway.yaml
+++ b/turing-talos/apps/envoy-gateways/public-gateway.yaml
@@ -7,3 +7,34 @@ spec:
   addresses:
   - type: IPAddress
     value: 192.168.1.55
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: All
+  - name: https
+    protocol: HTTPS
+    port: 443
+    hostname: "*.jern.fi"
+    allowedRoutes:
+      namespaces:
+        from: All
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        name: wildcard-jern-fi-cert
+  - name: https-apex
+    protocol: HTTPS
+    port: 443
+    hostname: jern.fi
+    allowedRoutes:
+      namespaces:
+        from: All
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        name: apex-jern-fi-cert

--- a/turing-talos/apps/jellyfin/httproute.yaml
+++ b/turing-talos/apps/jellyfin/httproute.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: jellyfin
+spec:
+  parentRefs:
+  - name: envoy-private
+    namespace: envoy-gateway-system
+    sectionName: https
+  hostnames:
+  - jellyfin.jern.fi
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: jellyfin
+      port: 80

--- a/turing-talos/apps/jellyfin/kustomization.yaml
+++ b/turing-talos/apps/jellyfin/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - namespace.yaml
 - certificate.yaml
 - ingress.yaml
+- httproute.yaml
 - jellyfin-pv.yaml
 patches:
 - path: jellyfin-data-pvc.yaml

--- a/turing-talos/apps/opencloud/httproute.yaml
+++ b/turing-talos/apps/opencloud/httproute.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: opencloud
+spec:
+  parentRefs:
+  - name: envoy-private
+    namespace: envoy-gateway-system
+    sectionName: https
+  hostnames:
+  - opencloud.jern.fi
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: opencloud
+      port: 80

--- a/turing-talos/apps/opencloud/kustomization.yaml
+++ b/turing-talos/apps/opencloud/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - namespace.yaml
 - certificate.yaml
 - ingress.yaml
+- httproute.yaml
 - opencloud-pv.yaml
 - external-secret.yaml
 patches:

--- a/turing-talos/apps/personal-blog/httproute.yaml
+++ b/turing-talos/apps/personal-blog/httproute.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: personal-blog
+spec:
+  parentRefs:
+  - name: envoy-public
+    namespace: envoy-gateway-system
+    sectionName: https
+  hostnames:
+  - lennart.jern.fi
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: personal-blog
+      port: 8080

--- a/turing-talos/apps/personal-blog/kustomization.yaml
+++ b/turing-talos/apps/personal-blog/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
 - ../../../personal-blog/base
 - namespace.yaml
 - ingress.yaml
+- httproute.yaml


### PR DESCRIPTION
- Introduce HTTPRoute manifests for blog, jellyfin, opencloud, and personal-blog apps in both KinD and turing-talos overlays
- Update kustomization.yaml files to include new HTTPRoute resources
- Add apex certificate and listener for jern.fi to envoy-gateways
- Update public and private gateway listeners for HTTPS apex domain