### PR TITLE
Add HTTPRoute for Keycloak and enable HTTP in turing-talos

### DIFF
--- a/keycloak/overlays/kind/httproute.yaml
+++ b/keycloak/overlays/kind/httproute.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: keycloak
+spec:
+  parentRefs:
+  - name: envoy-private
+    namespace: envoy-gateway-system
+    sectionName: https
+  hostnames:
+  - keycloak.local
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: keycloak-service
+      port: 8080

--- a/keycloak/overlays/kind/kustomization.yaml
+++ b/keycloak/overlays/kind/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - ../../base
 - certificate.yaml
 - ingress.yaml
+- httproute.yaml
 patches:
 - target:
     kind: Keycloak

--- a/turing-talos/apps/keycloak/httproute.yaml
+++ b/turing-talos/apps/keycloak/httproute.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: keycloak
+spec:
+  parentRefs:
+  - name: envoy-private
+    namespace: envoy-gateway-system
+    sectionName: https
+  hostnames:
+  - keycloak.jern.fi
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: keycloak-service
+      port: 8080

--- a/turing-talos/apps/keycloak/keycloak.yaml
+++ b/turing-talos/apps/keycloak/keycloak.yaml
@@ -3,5 +3,7 @@ kind: Keycloak
 metadata:
   name: keycloak
 spec:
+  http:
+    httpEnabled: true
   hostname:
     hostname: keycloak.jern.fi

--- a/turing-talos/apps/keycloak/kustomization.yaml
+++ b/turing-talos/apps/keycloak/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
 - ../../../keycloak/base
 - certificate.yaml
 - ingress.yaml
+- httproute.yaml
 patches:
 - path: keycloak.yaml


### PR DESCRIPTION
- Introduce HTTPRoute manifests for Keycloak in KinD and turing-talos
- Enable HTTP endpoint in turing-talos Keycloak deployment