### PR TITLE
Add HTTPRoute and insecure config for ArgoCD in KinD and Talos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Readme
 
 1. Install cert-manager: `kubectl apply -k cert-manager/overlays/<overlay>`
-2. Install argocd: `kubectl apply -k argocd/overlays/<overlay>`
-3. Add all applications: `kubectl apply -k apps/overlays/<overlay>`
+2. Install Gateway API CRDs: `kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml`
+3. Install argocd: `kubectl apply -k argocd/overlays/<overlay>`
+4. Add all applications: `kubectl apply -k apps/overlays/<overlay>`
 
 The `apps` folder contains argocd Applications including an "app-of-apps".
 
@@ -32,6 +33,7 @@ sudo kind get kubeconfig > kubeconfig.yaml
 export KUBECONFIG=kubeconfig.yaml
 
 kubectl apply -k cert-manager/overlays/kind
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
 kubectl apply -k argocd/overlays/kind
 
 # Login and check that it is working

--- a/argocd/overlays/kind/argocd-cmd-params-cm.yaml
+++ b/argocd/overlays/kind/argocd-cmd-params-cm.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmd-params-cm
+data:
+  server.insecure: "true"

--- a/argocd/overlays/kind/httproute.yaml
+++ b/argocd/overlays/kind/httproute.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: argocd
+spec:
+  parentRefs:
+  - name: envoy-private
+    namespace: envoy-gateway-system
+    sectionName: https
+  hostnames:
+  - argocd.local
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: argocd-server
+      port: 80

--- a/argocd/overlays/kind/ingress.yaml
+++ b/argocd/overlays/kind/ingress.yaml
@@ -1,14 +1,8 @@
-# https://argoproj.github.io/argo-cd/operator-manual/ingress/#ssl-passthrough-with-cert-manager-and-lets-encrypt
+# https://argoproj.github.io/argo-cd/operator-manual/ingress/
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: argocd-server-ingress
-  annotations:
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    # If you encounter a redirect loop or are getting a 307 response code
-    # then you need to force the nginx ingress to connect to the backend using HTTPS.
-    #
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 spec:
   ingressClassName: nginx
   rules:
@@ -19,10 +13,10 @@ spec:
           service:
             name: argocd-server
             port:
-              name: https
+              name: http
         path: /
         pathType: Prefix
   tls:
   - hosts:
     - argocd.local
-    secretName: argocd-secret # do not change, this is provided by Argo CD
+    secretName: argocd-secret

--- a/argocd/overlays/kind/kustomization.yaml
+++ b/argocd/overlays/kind/kustomization.yaml
@@ -14,3 +14,6 @@ resources:
 - ingress.yaml
 - selfsigned-issuer.yaml
 - certificate.yaml
+- httproute.yaml
+patches:
+- path: argocd-cmd-params-cm.yaml

--- a/chainsaw-test.yaml
+++ b/chainsaw-test.yaml
@@ -27,6 +27,11 @@ spec:
             (conditions[?type == 'Available']):
             - status: 'True'
   - try:
+    # Install Gateway API CRDs (needed before argocd, which includes an HTTPRoute)
+    - script:
+        timeout: 1m
+        content: kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+  - try:
     # Apply argocd manifests
     - script:
         timeout: 1m
@@ -220,7 +225,7 @@ spec:
         kind: Gateway
         name: envoy-public
         namespace: envoy-gateway-system
-  # argocd - Note: won't be ready until the ingress has an external IP
+  # argocd - Note: won't be ready until the gateway has an external IP
   - try:
     - script:
         timeout: 10s

--- a/turing-talos/apps/argocd/argocd-cmd-params-cm.yaml
+++ b/turing-talos/apps/argocd/argocd-cmd-params-cm.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmd-params-cm
+data:
+  server.insecure: "true"

--- a/turing-talos/apps/argocd/httproute.yaml
+++ b/turing-talos/apps/argocd/httproute.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: argocd
+spec:
+  parentRefs:
+  - name: envoy-private
+    namespace: envoy-gateway-system
+    sectionName: https
+  hostnames:
+  - argocd.jern.fi
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: argocd-server
+      port: 80

--- a/turing-talos/apps/argocd/ingress.yaml
+++ b/turing-talos/apps/argocd/ingress.yaml
@@ -1,14 +1,7 @@
-# https://argoproj.github.io/argo-cd/operator-manual/ingress/#ssl-passthrough-with-cert-manager-and-lets-encrypt
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: argocd-server-ingress
-  annotations:
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    # If you encounter a redirect loop or are getting a 307 response code
-    # then you need to force the nginx ingress to connect to the backend using HTTPS.
-    #
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 spec:
   ingressClassName: nginx
   rules:
@@ -19,10 +12,10 @@ spec:
           service:
             name: argocd-server
             port:
-              name: https
+              name: http
         path: /
         pathType: Prefix
   tls:
   - hosts:
     - argocd.jern.fi
-    secretName: argocd-secret # do not change, this is provided by Argo CD
+    secretName: argocd-secret

--- a/turing-talos/apps/argocd/kustomization.yaml
+++ b/turing-talos/apps/argocd/kustomization.yaml
@@ -12,6 +12,8 @@ resources:
 - letsencrypt-prod.yaml
 - letsencrypt-staging.yaml
 - certificate.yaml
+- httproute.yaml
 patches:
 - path: argocd-cm.yaml
 - path: argocd-rbac-cm.yaml
+- path: argocd-cmd-params-cm.yaml


### PR DESCRIPTION
- Introduce HTTPRoute for Envoy Gateway integration
- Patch ArgoCD to run in insecure mode for local and Talos
- Update Ingress to use HTTP backend instead of HTTPS