### PR TITLE
Add Jellyfin Keycloak SSO

### DIFF
--- a/apps/kind/jellyfin-app.yaml
+++ b/apps/kind/jellyfin-app.yaml
@@ -3,7 +3,7 @@ kind: Application
 metadata:
   name: jellyfin
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "4"
 spec:
   destination:
     namespace: jellyfin

--- a/chainsaw-test.yaml
+++ b/chainsaw-test.yaml
@@ -572,6 +572,27 @@ spec:
     - podLogs:
         name: jellyfin
         namespace: jellyfin
+  # Verify Jellyfin SSO plugin configuration
+  - try:
+    - script:
+        timeout: 30s
+        content: |
+          echo "=== Verifying Jellyfin SSO Plugin ConfigMap ==="
+          kubectl get configmap jellyfin-sso-config -n jellyfin -o jsonpath='{.data.SSO-Auth\.xml}' | grep -q 'OidEndpoint' && echo "SSO-Auth.xml present and contains OidEndpoint"
+          echo ""
+          echo "=== Verifying SSO plugin DLL was installed by the init container ==="
+          POD=$(kubectl get pod -n jellyfin -l app.kubernetes.io/name=jellyfin -o jsonpath='{.items[0].metadata.name}')
+          kubectl exec -n jellyfin "${POD}" -c jellyfin -- find /config/plugins -iname 'SSO-Auth.dll'
+    catch:
+    - script:
+        timeout: 30s
+        content: |
+          echo "=== Jellyfin SSO ConfigMap ==="
+          kubectl get configmap jellyfin-sso-config -n jellyfin -o yaml
+          echo "=== Jellyfin Deployment ==="
+          kubectl get deployment jellyfin -n jellyfin -o yaml
+          echo "=== Jellyfin install-sso-plugin init container logs ==="
+          kubectl logs -n jellyfin -l app.kubernetes.io/name=jellyfin -c install-sso-plugin --tail=100
   # opencloud
   - try:
     - script:

--- a/jellyfin/components/keycloak-sso/README.md
+++ b/jellyfin/components/keycloak-sso/README.md
@@ -1,0 +1,66 @@
+# Keycloak SSO plugin for Jellyfin
+
+This component installs the [9p4/jellyfin-plugin-sso](https://github.com/9p4/jellyfin-plugin-sso)
+plugin (the project is archived, but the last release keeps working) so Jellyfin
+can authenticate against the shared Keycloak realm
+(`keycloak/components/homelab-realm`).
+
+Due to Kustomize security restrictions, files cannot be referenced from outside
+the overlay directory, so each environment has its own `SSO-Auth.xml` file.
+
+## How it works
+
+An init container downloads the pinned plugin release directly from GitHub
+(no calls to the GitHub API at runtime, to avoid CI firewall issues) into the
+persistent `jellyfin-config` volume, then seeds the plugin's configuration
+file (`SSO-Auth.xml`) on first run only, so changes made through the Jellyfin
+admin UI afterwards are not overwritten on every restart.
+
+## Setup Instructions
+
+### 1. Copy the SSO-Auth.xml file to your overlay
+
+```bash
+cp jellyfin/components/keycloak-sso/SSO-Auth.xml.example <your-overlay-path>/SSO-Auth.xml
+```
+
+### 2. Update the OIDC endpoint
+
+Edit the copied `SSO-Auth.xml` and point `OidEndpoint` at your Keycloak
+deployment:
+
+```xml
+<OidEndpoint>https://keycloak.example.com/realms/homelab</OidEndpoint>
+```
+
+### 3. Add the component and configMapGenerator to your overlay
+
+```yaml
+components:
+- ../../components/keycloak-sso
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+- name: jellyfin-sso-config
+  files:
+  - SSO-Auth.xml
+```
+
+## Configuration Reference
+
+| Field | Description |
+|-------|--------------|
+| `OidEndpoint` | Keycloak realm issuer URL |
+| `OidClientId` | The `jellyfin` client from the shared realm |
+| `AdminRoles` | Realm roles granted Jellyfin admin access (`jellyfinAdmin`) |
+| `Roles` | Realm roles allowed to sign in (`jellyfinUser`, `jellyfinAdmin`) |
+| `RoleClaim` | Claim holding the roles (`realm_access.roles`, from the realm's `roles` client scope) |
+
+## Examples
+
+See the following directories for working examples:
+
+- `jellyfin/overlays/kind/` - KinD development environment
+- `turing-talos/apps/jellyfin/` - Production turing-talos environment

--- a/jellyfin/components/keycloak-sso/SSO-Auth.xml.example
+++ b/jellyfin/components/keycloak-sso/SSO-Auth.xml.example
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PluginConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <OidConfigs>
+    <item>
+      <key>
+        <string>Keycloak</string>
+      </key>
+      <value>
+        <PluginConfiguration>
+          <OidEndpoint>https://keycloak.example.com/realms/homelab</OidEndpoint>
+          <OidClientId>jellyfin</OidClientId>
+          <OidSecret />
+          <Enabled>true</Enabled>
+          <EnableAuthorization>true</EnableAuthorization>
+          <EnableAllFolders>true</EnableAllFolders>
+          <EnabledFolders />
+          <AdminRoles>
+            <string>jellyfinAdmin</string>
+          </AdminRoles>
+          <Roles>
+            <string>jellyfinUser</string>
+            <string>jellyfinAdmin</string>
+          </Roles>
+          <EnableFolderRoles>false</EnableFolderRoles>
+          <FolderRoleMappings />
+          <RoleClaim>realm_access.roles</RoleClaim>
+          <OidScopes />
+          <DisablePushedAuthorization>true</DisablePushedAuthorization>
+          <DoNotValidateEndpoints>false</DoNotValidateEndpoints>
+          <DoNotValidateIssuerName>false</DoNotValidateIssuerName>
+        </PluginConfiguration>
+      </value>
+    </item>
+  </OidConfigs>
+</PluginConfiguration>

--- a/jellyfin/components/keycloak-sso/deployment-patch.yaml
+++ b/jellyfin/components/keycloak-sso/deployment-patch.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jellyfin
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: install-sso-plugin
+        # 9p4/jellyfin-plugin-sso is archived (no further releases expected),
+        # so pinning this version is expected to remain valid long-term.
+        # The plugin GUID comes from the plugin's own manifest
+        # (SSOPlugin.cs / build.yaml in that repo).
+        image: docker.io/library/alpine:3.21
+        command:
+        - sh
+        - -c
+        - |
+          set -ex
+          apk add --no-cache curl unzip
+          PLUGIN_GUID="505ce9d1-d916-42fa-86ca-673ef241d7df"
+          PLUGIN_VERSION="4.0.0.3"
+          PLUGIN_DIR="/config/plugins/${PLUGIN_GUID}_${PLUGIN_VERSION}"
+          if [ ! -f "${PLUGIN_DIR}/SSO-Auth.dll" ]; then
+            mkdir -p "${PLUGIN_DIR}"
+            curl -fL --retry 3 --retry-delay 5 -o /tmp/sso-plugin.zip \
+              "https://github.com/9p4/jellyfin-plugin-sso/releases/download/v${PLUGIN_VERSION}/sso-authentication_${PLUGIN_VERSION}.zip"
+            unzip -o -j /tmp/sso-plugin.zip -d "${PLUGIN_DIR}"
+          fi
+          mkdir -p /config/plugins/configurations
+          if [ ! -f /config/plugins/configurations/SSO-Auth.xml ]; then
+            cp /sso-config/SSO-Auth.xml /config/plugins/configurations/SSO-Auth.xml
+          fi
+        volumeMounts:
+        - name: jellyfin-config
+          mountPath: /config
+        - name: jellyfin-sso-config
+          mountPath: /sso-config
+          readOnly: true
+      volumes:
+      - name: jellyfin-sso-config
+        configMap:
+          name: jellyfin-sso-config

--- a/jellyfin/components/keycloak-sso/kustomization.yaml
+++ b/jellyfin/components/keycloak-sso/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+metadata:
+  name: keycloak-sso
+
+patches:
+- path: deployment-patch.yaml
+  target:
+    kind: Deployment
+    name: jellyfin

--- a/jellyfin/overlays/kind/SSO-Auth.xml
+++ b/jellyfin/overlays/kind/SSO-Auth.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PluginConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <OidConfigs>
+    <item>
+      <key>
+        <string>Keycloak</string>
+      </key>
+      <value>
+        <PluginConfiguration>
+          <OidEndpoint>https://keycloak.local/realms/homelab</OidEndpoint>
+          <OidClientId>jellyfin</OidClientId>
+          <OidSecret />
+          <Enabled>true</Enabled>
+          <EnableAuthorization>true</EnableAuthorization>
+          <EnableAllFolders>true</EnableAllFolders>
+          <EnabledFolders />
+          <AdminRoles>
+            <string>jellyfinAdmin</string>
+          </AdminRoles>
+          <Roles>
+            <string>jellyfinUser</string>
+            <string>jellyfinAdmin</string>
+          </Roles>
+          <EnableFolderRoles>false</EnableFolderRoles>
+          <FolderRoleMappings />
+          <RoleClaim>realm_access.roles</RoleClaim>
+          <OidScopes />
+          <DisablePushedAuthorization>true</DisablePushedAuthorization>
+          <DoNotValidateEndpoints>false</DoNotValidateEndpoints>
+          <DoNotValidateIssuerName>false</DoNotValidateIssuerName>
+        </PluginConfiguration>
+      </value>
+    </item>
+  </OidConfigs>
+</PluginConfiguration>

--- a/jellyfin/overlays/kind/kustomization.yaml
+++ b/jellyfin/overlays/kind/kustomization.yaml
@@ -12,3 +12,14 @@ resources:
 - ../../base
 - namespace.yaml
 - httproute.yaml
+
+components:
+- ../../components/keycloak-sso
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+- name: jellyfin-sso-config
+  files:
+  - SSO-Auth.xml

--- a/keycloak/components/homelab-realm/keycloak-realm-import.yaml
+++ b/keycloak/components/homelab-realm/keycloak-realm-import.yaml
@@ -40,6 +40,10 @@ spec:
         description: Guest role with limited access
       - name: opencloudSpaceAdmin
         description: OpenCloud Space Administrator role
+      - name: jellyfinAdmin
+        description: Jellyfin administrator role
+      - name: jellyfinUser
+        description: Standard Jellyfin user role
       - name: offline_access
         description: "${role_offline-access}"
       - name: uma_authorization
@@ -107,9 +111,11 @@ spec:
     - name: users
       realmRoles:
       - opencloudUser
+      - jellyfinUser
     - name: admins
       realmRoles:
       - opencloudAdmin
+      - jellyfinAdmin
     - name: ArgoCDAdmins
       path: /ArgoCDAdmins
       subGroups: []
@@ -576,6 +582,27 @@ spec:
       - email
       optionalClientScopes:
       - offline_access
+    # index 7: Jellyfin (public PKCE client for the 9p4/jellyfin-plugin-sso
+    # plugin). Redirect URIs are patched per-environment.
+    - clientId: jellyfin
+      name: Jellyfin
+      description: Jellyfin Media Server
+      enabled: true
+      clientAuthenticatorType: client-secret
+      publicClient: true
+      protocol: openid-connect
+      standardFlowEnabled: true
+      implicitFlowEnabled: false
+      directAccessGrantsEnabled: false
+      serviceAccountsEnabled: false
+      fullScopeAllowed: false
+      defaultClientScopes:
+      - openid
+      - email
+      - profile
+      - roles
+      attributes:
+        pkce.code.challenge.method: S256
     # No users are defined here. Environments that need one (e.g. the KinD
     # test setup) add them through a patch, production users are managed in
     # Keycloak.

--- a/keycloak/overlays/kind/kustomization.yaml
+++ b/keycloak/overlays/kind/kustomization.yaml
@@ -37,6 +37,22 @@ patches:
     - op: add
       path: /spec/realm/clients/2/attributes/post.logout.redirect.uris
       value: https://opencloud.local/*
+# Configure Jellyfin client (index 7) redirect URIs for KinD environment
+- target:
+    kind: KeycloakRealmImport
+    name: homelab-realm
+  patch: |-
+    - op: add
+      path: /spec/realm/clients/7/redirectUris
+      value:
+        - https://jellyfin.local/sso/OID/redirect/Keycloak
+    - op: add
+      path: /spec/realm/clients/7/webOrigins
+      value:
+        - https://jellyfin.local
+    - op: add
+      path: /spec/realm/clients/7/baseUrl
+      value: https://jellyfin.local
 # Test user for the KinD environment. The username matches the OpenCloud admin
 # account created by IDM_ADMIN_PASSWORD, so signing in resolves to that account.
 - target:
@@ -58,6 +74,7 @@ patches:
               temporary: false
           realmRoles:
             - opencloudAdmin
+            - jellyfinAdmin
             - default-roles-homelab
           groups:
             - admins

--- a/turing-talos/apps/jellyfin-app.yaml
+++ b/turing-talos/apps/jellyfin-app.yaml
@@ -3,7 +3,7 @@ kind: Application
 metadata:
   name: jellyfin
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "4"
 spec:
   destination:
     namespace: jellyfin

--- a/turing-talos/apps/jellyfin/SSO-Auth.xml
+++ b/turing-talos/apps/jellyfin/SSO-Auth.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PluginConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <OidConfigs>
+    <item>
+      <key>
+        <string>Keycloak</string>
+      </key>
+      <value>
+        <PluginConfiguration>
+          <OidEndpoint>https://keycloak.jern.fi/realms/jern.fi</OidEndpoint>
+          <OidClientId>jellyfin</OidClientId>
+          <OidSecret />
+          <Enabled>true</Enabled>
+          <EnableAuthorization>true</EnableAuthorization>
+          <EnableAllFolders>true</EnableAllFolders>
+          <EnabledFolders />
+          <AdminRoles>
+            <string>jellyfinAdmin</string>
+          </AdminRoles>
+          <Roles>
+            <string>jellyfinUser</string>
+            <string>jellyfinAdmin</string>
+          </Roles>
+          <EnableFolderRoles>false</EnableFolderRoles>
+          <FolderRoleMappings />
+          <RoleClaim>realm_access.roles</RoleClaim>
+          <OidScopes />
+          <DisablePushedAuthorization>true</DisablePushedAuthorization>
+          <DoNotValidateEndpoints>false</DoNotValidateEndpoints>
+          <DoNotValidateIssuerName>false</DoNotValidateIssuerName>
+        </PluginConfiguration>
+      </value>
+    </item>
+  </OidConfigs>
+</PluginConfiguration>

--- a/turing-talos/apps/jellyfin/kustomization.yaml
+++ b/turing-talos/apps/jellyfin/kustomization.yaml
@@ -9,5 +9,17 @@ resources:
 - namespace.yaml
 - httproute.yaml
 - jellyfin-pv.yaml
+
+components:
+- ../../../jellyfin/components/keycloak-sso
+
 patches:
 - path: jellyfin-data-pvc.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+- name: jellyfin-sso-config
+  files:
+  - SSO-Auth.xml

--- a/turing-talos/apps/keycloak/kustomization.yaml
+++ b/turing-talos/apps/keycloak/kustomization.yaml
@@ -38,7 +38,7 @@ patches:
       path: /spec/realm/defaultRole/name
       value: default-roles-jern.fi
     - op: replace
-      path: /spec/realm/roles/realm/6/name
+      path: /spec/realm/roles/realm/8/name
       value: default-roles-jern.fi
     - op: replace
       path: /spec/realm/clients/0/baseUrl
@@ -82,3 +82,20 @@ patches:
     - op: add
       path: /spec/realm/clients/6/adminUrl
       value: https://argocd.jern.fi
+# Configure Jellyfin client redirect URIs for turing-talos environment
+# Note: jellyfin client is at index 7 (last one)
+- target:
+    kind: KeycloakRealmImport
+    name: homelab-realm
+  patch: |-
+    - op: add
+      path: /spec/realm/clients/7/redirectUris
+      value:
+        - https://jellyfin.jern.fi/sso/OID/redirect/Keycloak
+    - op: add
+      path: /spec/realm/clients/7/webOrigins
+      value:
+        - https://jellyfin.jern.fi
+    - op: add
+      path: /spec/realm/clients/7/baseUrl
+      value: https://jellyfin.jern.fi


### PR DESCRIPTION
Introduce a Jellyfin keycloak-sso Kustomize component with an init container that installs the SSO plugin and seeds SSO-Auth.xml from a ConfigMap.

Add Jellyfin realm roles/client redirect patches for kind and turing-talos.