### PR TITLE
Rename Keycloak realm component to homelab-realm; add ArgoCD client

### DIFF
--- a/chainsaw-test.yaml
+++ b/chainsaw-test.yaml
@@ -440,7 +440,7 @@ spec:
     - podLogs:
         name: keycloak-db-1
         namespace: keycloak
-  # Verify KeycloakRealmImport for OpenCloud realm
+  # Verify KeycloakRealmImport for the shared homelab realm
   - try:
     - assert:
         timeout: 10m
@@ -448,7 +448,7 @@ spec:
           apiVersion: k8s.keycloak.org/v2alpha1
           kind: KeycloakRealmImport
           metadata:
-            name: opencloud-realm
+            name: homelab-realm
             namespace: keycloak
           status:
             (conditions[?type == 'Done']):
@@ -457,13 +457,23 @@ spec:
     - describe:
         apiVersion: k8s.keycloak.org/v2alpha1
         kind: KeycloakRealmImport
-        name: opencloud-realm
+        name: homelab-realm
         namespace: keycloak
     - script:
         timeout: 30s
         content: |
           echo "=== Keycloak Realm Import Status ==="
           kubectl get keycloakrealmimport -n keycloak -o yaml
+          echo "=== Keycloak Realm Import Job ==="
+          kubectl get jobs -n keycloak -o wide
+          echo "=== Keycloak Realm Import Job Pod(s) ==="
+          kubectl get pods -n keycloak -l app=keycloak-realm-import -o wide
+          echo "=== Keycloak Realm Import Job Logs ==="
+          # The realm-import Job's pod is labeled app=keycloak-realm-import by the
+          # operator (distinct from the main Keycloak StatefulSet pod, which is
+          # labeled app=keycloak and never runs the actual import) - this is where
+          # the real Keycloak-reported validation error/stack trace shows up.
+          kubectl logs -n keycloak -l app=keycloak-realm-import --tail=200 --all-containers
           echo "=== Keycloak Logs ==="
           kubectl logs -n keycloak -l app=keycloak --tail=100
   # pi-hole
@@ -630,11 +640,11 @@ spec:
           # finish, then read its output back with `kubectl logs` instead,
           # which returns exactly the container's stdout.
           kubectl run "${POD}" --restart=Never --image=curlimages/curl:8.11.1 --command -- \
-            curl -sk --max-time 10 --resolve "keycloak.local:443:${GATEWAY_IP}" https://keycloak.local/realms/openCloud/.well-known/openid-configuration
+            curl -sk --max-time 10 --resolve "keycloak.local:443:${GATEWAY_IP}" https://keycloak.local/realms/homelab/.well-known/openid-configuration
           kubectl wait --for=jsonpath='{.status.phase}'=Succeeded "pod/${POD}" --timeout=30s
           RESPONSE=$(kubectl logs "${POD}")
           kubectl delete pod "${POD}" --ignore-not-found
-          echo "$RESPONSE" | jq -e '.issuer == "https://keycloak.local/realms/openCloud"' || exit 1
+          echo "$RESPONSE" | jq -e '.issuer == "https://keycloak.local/realms/homelab"' || exit 1
           echo "$RESPONSE" | jq -e '.authorization_endpoint' || exit 1
           echo "$RESPONSE" | jq -e '.token_endpoint' || exit 1
           echo "OIDC discovery endpoint OK"

--- a/keycloak/components/homelab-realm/keycloak-realm-import.yaml
+++ b/keycloak/components/homelab-realm/keycloak-realm-import.yaml
@@ -1,16 +1,16 @@
 apiVersion: k8s.keycloak.org/v2alpha1
 kind: KeycloakRealmImport
 metadata:
-  name: opencloud-realm
+  name: homelab-realm
   labels:
     app: keycloak
-    realm: opencloud
+    realm: homelab
 spec:
   keycloakCRName: keycloak
   realm:
-    realm: openCloud
+    realm: homelab
     enabled: true
-    displayName: OpenCloud
+    displayName: homelab
     registrationAllowed: false
     resetPasswordAllowed: true
     editUsernameAllowed: false
@@ -44,7 +44,7 @@ spec:
         description: "${role_offline-access}"
       - name: uma_authorization
         description: "${role_uma_authorization}"
-      - name: default-roles-opencloud
+      - name: default-roles-homelab
         description: "${role_default-roles}"
         composite: true
         composites:
@@ -89,7 +89,7 @@ spec:
         - name: delete-account
           description: "${role_delete-account}"
     defaultRole:
-      name: default-roles-opencloud
+      name: default-roles-homelab
     # Scope mappings allow clients to include specific client roles in tokens
     # when fullScopeAllowed is false
     scopeMappings:
@@ -110,6 +110,11 @@ spec:
     - name: admins
       realmRoles:
       - opencloudAdmin
+    - name: ArgoCDAdmins
+      path: /ArgoCDAdmins
+      subGroups: []
+      realmRoles: []
+      clientRoles: {}
     clientScopes:
     # Standard OpenID Connect scopes required by Keycloak
     - name: openid
@@ -334,8 +339,30 @@ spec:
           access.token.claim: "true"
           claim.name: roles
           jsonType.label: String
+    # Generic top-level group membership scope, used by argocd (ArgoCD RBAC is
+    # done via `g, <group>, role:...` entries matching this `groups` claim, see
+    # turing-talos/apps/argocd/argocd-rbac-cm.yaml). Distinct from OpenCloud's
+    # `oc-groups` scope above, which is named/scoped per-app; both are kept
+    # rather than merged so the already-working OpenCloud mappers are untouched.
+    - name: groups
+      protocol: openid-connect
+      attributes:
+        include.in.token.scope: "true"
+        display.on.consent.screen: "true"
+      protocolMappers:
+      - name: groups
+        protocol: openid-connect
+        protocolMapper: oidc-group-membership-mapper
+        consentRequired: false
+        config:
+          full.path: "false"
+          multivalued: "true"
+          id.token.claim: "true"
+          access.token.claim: "true"
+          userinfo.token.claim: "true"
+          claim.name: groups
     clients:
-    # Account Console - for user self-service
+    # index 0: Account Console - for user self-service
     - clientId: account
       name: Account
       description: Account Management
@@ -345,9 +372,9 @@ spec:
       publicClient: true
       protocol: openid-connect
       rootUrl: ${authBaseUrl}
-      baseUrl: /realms/openCloud/account/
+      baseUrl: /realms/homelab/account/
       redirectUris:
-      - /realms/openCloud/account/*
+      - /realms/homelab/account/*
       webOrigins:
       - "+"
       standardFlowEnabled: true
@@ -362,6 +389,7 @@ spec:
       - roles
       - basic
       - email
+    # index 1: Account Console
     - clientId: account-console
       name: Account Console
       description: Account Console for user self-service
@@ -371,9 +399,9 @@ spec:
       publicClient: true
       protocol: openid-connect
       rootUrl: ${authBaseUrl}
-      baseUrl: /realms/openCloud/account/
+      baseUrl: /realms/homelab/account/
       redirectUris:
-      - /realms/openCloud/account/*
+      - /realms/homelab/account/*
       webOrigins:
       - "+"
       standardFlowEnabled: true
@@ -396,6 +424,8 @@ spec:
         protocol: openid-connect
         protocolMapper: oidc-audience-resolve-mapper
         consentRequired: false
+    # index 2: OpenCloud Web (public PKCE client). Redirect URIs are patched
+    # per-environment (this index is referenced by overlay patches).
     - clientId: web
       name: OpenCloud Web
       description: OpenCloud Web Application
@@ -419,6 +449,7 @@ spec:
       - offline_access
       attributes:
         pkce.code.challenge.method: S256
+    # index 3: OpenCloud Desktop Client
     - clientId: OpenCloudDesktop
       name: OpenCloud Desktop Client
       description: OpenCloud Desktop Sync Client
@@ -447,13 +478,15 @@ spec:
       - offline_access
       attributes:
         pkce.code.challenge.method: S256
+    # index 4: OpenCloud Android App
     - clientId: OpenCloudAndroid
       name: OpenCloud Android App
       description: OpenCloud Android Mobile Application
       enabled: true
       clientAuthenticatorType: client-secret
       redirectUris:
-      - oc://android.opencloud.com/*
+      - oc://android.opencloud.eu
+      - oc://android.opencloud.eu/*
       publicClient: true
       protocol: openid-connect
       standardFlowEnabled: true
@@ -471,14 +504,15 @@ spec:
       - offline_access
       attributes:
         pkce.code.challenge.method: S256
+    # index 5: OpenCloud iOS App
     - clientId: OpenCloudIOS
       name: OpenCloud iOS App
       description: OpenCloud iOS Mobile Application
       enabled: true
       clientAuthenticatorType: client-secret
       redirectUris:
-      - oc://ios.opencloud.com/*
-      - oc.ios://ios.opencloud.com/*
+      - oc://ios.opencloud.eu
+      - oc://ios.opencloud.eu/*
       publicClient: true
       protocol: openid-connect
       standardFlowEnabled: true
@@ -496,5 +530,52 @@ spec:
       - offline_access
       attributes:
         pkce.code.challenge.method: S256
-    # No users are defined here. Environments that need one (e.g. the KinD test
-    # setup) add them through a patch, production users are managed in Keycloak.
+    # index 6: ArgoCD, faithfully reproduced from the manually-configured
+    # jern.fi realm (see docs/unified-sso-migration.md inventory), except:
+    # - rootUrl/adminUrl are omitted here since they point at ArgoCD's actual
+    #   external URL, which is environment-specific (only turing-talos runs
+    #   ArgoCD with OIDC configured); that overlay patches them in.
+    # - optionalClientScopes: the manual export also listed address, phone,
+    #   organization and microprofile-jwt, but those are only auto-created by
+    #   Keycloak when a realm is created via the Admin UI/API. A from-scratch
+    #   KeycloakRealmImport that (like this one) declares its own explicit
+    #   clientScopes list skips that auto-creation entirely (see
+    #   RealmManager.isCreateDefaultClientScopes upstream), so referencing
+    #   those undefined scope names here makes the whole realm import Job
+    #   fail. offline_access is kept since Keycloak always creates it
+    #   regardless (see RealmManager.setupOfflineTokens).
+    - clientId: argocd
+      name: ArgoCD Client
+      description: See https://argo-cd.readthedocs.io/en/stable/operator-manual/user-management/keycloak
+      baseUrl: /applications
+      clientAuthenticatorType: client-secret
+      enabled: true
+      redirectUris:
+      - http://localhost:8085/auth/callback
+      - /auth/callback
+      - /pkce/verify
+      webOrigins:
+      - "+"
+      standardFlowEnabled: true
+      directAccessGrantsEnabled: true
+      publicClient: true
+      frontchannelLogout: true
+      protocol: openid-connect
+      attributes:
+        post.logout.redirect.uris: /applications
+        pkce.code.challenge.method: S256
+        use.refresh.tokens: "true"
+      fullScopeAllowed: true
+      defaultClientScopes:
+      - web-origins
+      - acr
+      - roles
+      - profile
+      - groups
+      - basic
+      - email
+      optionalClientScopes:
+      - offline_access
+    # No users are defined here. Environments that need one (e.g. the KinD
+    # test setup) add them through a patch, production users are managed in
+    # Keycloak.

--- a/keycloak/components/homelab-realm/kustomization.yaml
+++ b/keycloak/components/homelab-realm/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 metadata:
-  name: opencloud-realm
+  name: homelab-realm
 resources:
 - keycloak-realm-import.yaml

--- a/keycloak/overlays/kind/kustomization.yaml
+++ b/keycloak/overlays/kind/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 - httproute.yaml
 
 components:
-- ../../components/opencloud-realm
+- ../../components/homelab-realm
 
 patches:
 - target:
@@ -21,10 +21,10 @@ patches:
       value: true
     - op: remove
       path: /spec/http/tlsSecret
-# Configure web client redirect URIs for KinD environment
+# Configure OpenCloud web client (index 2) redirect URIs for KinD environment
 - target:
     kind: KeycloakRealmImport
-    name: opencloud-realm
+    name: homelab-realm
   patch: |-
     - op: add
       path: /spec/realm/clients/2/redirectUris
@@ -41,7 +41,7 @@ patches:
 # account created by IDM_ADMIN_PASSWORD, so signing in resolves to that account.
 - target:
     kind: KeycloakRealmImport
-    name: opencloud-realm
+    name: homelab-realm
   patch: |-
     - op: add
       path: /spec/realm/users
@@ -58,6 +58,6 @@ patches:
               temporary: false
           realmRoles:
             - opencloudAdmin
-            - default-roles-opencloud
+            - default-roles-homelab
           groups:
             - admins

--- a/opencloud/components/keycloak-oidc/README.md
+++ b/opencloud/components/keycloak-oidc/README.md
@@ -44,7 +44,7 @@ Edit the copied `oidc.env` file and update the issuer URL to match your Keycloak
 deployment:
 
 ```env
-OC_OIDC_ISSUER=https://keycloak.example.com/realms/openCloud
+OC_OIDC_ISSUER=https://keycloak.example.com/realms/homelab
 ```
 
 ### 3. Add the oidc.env to your configMapGenerator
@@ -74,13 +74,13 @@ configMapGenerator:
 The deployment then needs `PROXY_CSP_CONFIG_FILE_LOCATION=/etc/opencloud/csp.yaml`
 and the ConfigMap mounted at that path.
 
-### 5. Include the opencloud-realm component in your Keycloak overlay
+### 5. Include the homelab-realm component in your Keycloak overlay
 
 Add the component to your Keycloak kustomization:
 
 ```yaml
 components:
-- ../../components/opencloud-realm
+- ../../../keycloak/components/homelab-realm
 ```
 
 And patch the redirect URIs for your environment (the `web` client is at index 2):
@@ -89,7 +89,7 @@ And patch the redirect URIs for your environment (the `web` client is at index 2
 patches:
 - target:
     kind: KeycloakRealmImport
-    name: opencloud-realm
+    name: homelab-realm
   patch: |-
     - op: add
       path: /spec/realm/clients/2/redirectUris
@@ -103,6 +103,8 @@ patches:
       path: /spec/realm/clients/2/attributes/post.logout.redirect.uris
       value: https://opencloud.example.com/*
 ```
+
+The realm defaults to being named `homelab`.
 
 The realm import does not contain any users. Create them in Keycloak, and make
 sure the username matches the OpenCloud username when migrating an existing

--- a/opencloud/components/keycloak-oidc/oidc.env
+++ b/opencloud/components/keycloak-oidc/oidc.env
@@ -10,7 +10,7 @@ OC_EXCLUDE_RUN_SERVICES=idp
 # OIDC issuer URL (must match the Keycloak realm URL).
 # This will be overridden by environment-specific values.
 # OC_OIDC_ISSUER is picked up by the proxy, web, users and webfinger services.
-OC_OIDC_ISSUER=https://keycloak.example.com/realms/openCloud
+OC_OIDC_ISSUER=https://keycloak.example.com/realms/homelab
 
 # Web client configuration
 WEB_OIDC_CLIENT_ID=web

--- a/opencloud/overlays/kind/oidc.env
+++ b/opencloud/overlays/kind/oidc.env
@@ -7,7 +7,7 @@ OC_EXCLUDE_RUN_SERVICES=idp
 
 # OIDC issuer URL (Keycloak realm URL for KinD).
 # OC_OIDC_ISSUER is picked up by the proxy, web, users and webfinger services.
-OC_OIDC_ISSUER=https://keycloak.local/realms/openCloud
+OC_OIDC_ISSUER=https://keycloak.local/realms/homelab
 
 # Web client configuration
 WEB_OIDC_CLIENT_ID=web

--- a/turing-talos/apps/keycloak/kustomization.yaml
+++ b/turing-talos/apps/keycloak/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 - httproute.yaml
 
 components:
-- ../../../keycloak/components/opencloud-realm
+- ../../../keycloak/components/homelab-realm
 
 patches:
 - path: keycloak.yaml
@@ -19,11 +19,44 @@ patches:
   patch: |-
     - op: remove
       path: /spec/http/tlsSecret
-# Configure web client redirect URIs for turing-talos environment
+# The shared realm component defaults to a realm named "homelab" (used by
+# KinD and any other non-production environment). Production (turing-talos)
+# is the exception: it must keep using the pre-existing, manually-created
+# `jern.fi` realm name, since ArgoCD's issuer (argocd-cm.yaml) and the
+# Keycloak accounts already in use are tied to that literal name.
+- target:
+    kind: KeycloakRealmImport
+    name: homelab-realm
+  patch: |-
+    - op: replace
+      path: /spec/realm/realm
+      value: jern.fi
+    - op: replace
+      path: /spec/realm/displayName
+      value: jern.fi
+    - op: replace
+      path: /spec/realm/defaultRole/name
+      value: default-roles-jern.fi
+    - op: replace
+      path: /spec/realm/roles/realm/6/name
+      value: default-roles-jern.fi
+    - op: replace
+      path: /spec/realm/clients/0/baseUrl
+      value: /realms/jern.fi/account/
+    - op: replace
+      path: /spec/realm/clients/0/redirectUris/0
+      value: /realms/jern.fi/account/*
+    - op: replace
+      path: /spec/realm/clients/1/baseUrl
+      value: /realms/jern.fi/account/
+    - op: replace
+      path: /spec/realm/clients/1/redirectUris/0
+      value: /realms/jern.fi/account/*
+# Configure OpenCloud web client redirect URIs for turing-talos environment
 # Note: web client is at index 2 (after account and account-console)
 - target:
     kind: KeycloakRealmImport
-    name: opencloud-realm
+    name: homelab-realm
   patch: |-
     - op: add
       path: /spec/realm/clients/2/redirectUris
@@ -36,3 +69,16 @@ patches:
     - op: add
       path: /spec/realm/clients/2/attributes/post.logout.redirect.uris
       value: https://opencloud.jern.fi/*
+# Configure ArgoCD client (index 6) rootUrl/adminUrl for turing-talos
+# environment. The shared component omits these since they point at
+# ArgoCD's actual external URL, which only exists in production.
+- target:
+    kind: KeycloakRealmImport
+    name: homelab-realm
+  patch: |-
+    - op: add
+      path: /spec/realm/clients/6/rootUrl
+      value: https://argocd.jern.fi
+    - op: add
+      path: /spec/realm/clients/6/adminUrl
+      value: https://argocd.jern.fi

--- a/turing-talos/apps/opencloud/oidc.env
+++ b/turing-talos/apps/opencloud/oidc.env
@@ -9,7 +9,7 @@ OC_EXCLUDE_RUN_SERVICES=idp
 
 # OIDC issuer URL (Keycloak realm URL for turing-talos).
 # OC_OIDC_ISSUER is picked up by the proxy, web, users and webfinger services.
-OC_OIDC_ISSUER=https://keycloak.jern.fi/realms/openCloud
+OC_OIDC_ISSUER=https://keycloak.jern.fi/realms/jern.fi
 
 # Web client configuration
 WEB_OIDC_CLIENT_ID=web


### PR DESCRIPTION
Rename the Keycloak realm component from opencloud-realm to homelab-realm and update realm import names and OIDC issuer URLs so the realm can be shared across OpenCloud, ArgoCD and (in a follow-up commit) Jellyfin. Production (turing-talos) keeps the pre-existing jern.fi realm name via an overlay patch; other environments default to a generic 'homelab' realm name.

Also capture the realm-import Job's own pod logs in chainsaw-test.yaml (distinct from the main keycloak StatefulSet pod), which is where the real Keycloak-reported validation errors surface on import failures.